### PR TITLE
cgo: split windows/posix support

### DIFF
--- a/cgoflags_posix.go
+++ b/cgoflags_posix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package python
 
 // #cgo pkg-config: python-2.7

--- a/cgoflags_windows.go
+++ b/cgoflags_windows.go
@@ -1,0 +1,10 @@
+// +build windows
+
+package python
+
+// #cgo CFLAGS: -IC:/Python27/include
+// #cgo LDFLAGS: -LC:/Python27/libs -lpython27
+// #include "go-python.h"
+import "C"
+
+// EOF


### PR DESCRIPTION
Split cgo-flags support into Windows and POSIX.
Windows installations do not usually sport a pkg-config installation.

Updates #32.